### PR TITLE
Loop through all submitted form fields when e-mailing form data.

### DIFF
--- a/wagtail/wagtailforms/models.py
+++ b/wagtail/wagtailforms/models.py
@@ -295,7 +295,7 @@ class AbstractEmailForm(AbstractForm):
 
     def send_mail(self, form):
         addresses = [x.strip() for x in self.to_address.split(',')]
-        content = '\n'.join([x[1].label + ': ' + text_type(form.data.get(x[0])) for x in form.fields.items()])
+        content = '\n'.join([x[1].label + ': ' + text_type( ', '.join(dict(form.data.lists())[x[0]]) ) for x in form.fields.items()])
         send_mail(self.subject, content, addresses, self.from_address,)
 
     class Meta:


### PR DESCRIPTION
A form field with multiple checkboxes may introduce submissions that have more than one value. The `send_email` function would loop through all form fields and grab only the first item of each field, ignoring fields that may have multiple values selected. This is a side effect of using `QueryDict.get()`, which will only return the last value of a list.

This commit fixes that by first converting the `QueryDict` instance to a regular dict of lists so that `get` will return all values, then joining multiple items if needed.
